### PR TITLE
fix(nvim): corrige imports internos de LSP en config

### DIFF
--- a/config/nvim/lua/config/init.lua
+++ b/config/nvim/lua/config/init.lua
@@ -28,8 +28,8 @@ vim.schedule(function()
 end)
 
 -- Carga condicional de módulos
-if vim.fn.isdirectory(vim.fn.expand('~/.config/nvim/lua/lsp')) == 1 then
+if vim.fn.isdirectory(vim.fn.expand('~/.config/nvim/lua/plugins/lsp')) == 1 then
   vim.defer_fn(function()
-    safe_require('lsp.diagnostics')
+    safe_require('plugins.lsp.diagnostics')
   end, 0)
 end

--- a/config/nvim/lua/config/user.lua
+++ b/config/nvim/lua/config/user.lua
@@ -1,8 +1,8 @@
-local ok, user_config = pcall(require, 'lsp.defaults')
-local lsp_defaults = ok and require('lsp.defaults') or {}
+local ok, lsp_defaults = pcall(require, 'plugins.lsp.defaults')
+local user_config = {}
 
 if not ok then
-  user_config = {}
+  lsp_defaults = {}
 end
 
 local default_config = {


### PR DESCRIPTION
### Motivation
- Corregir errores de `require` que podían dejar la configuración LSP sin aplicarse porque apuntaban a módulos que no existen en la estructura actual del repositorio.

### Description
- En `config/nvim/lua/config/user.lua` se cambia la carga a `pcall(require, 'plugins.lsp.defaults')`, se inicializa `user_config = {}` y se usa `lsp_defaults = {}` como fallback para evitar un `require` redundante y errores silenciosos.
- En `config/nvim/lua/config/init.lua` se ajusta la verificación de directorio a `~/.config/nvim/lua/plugins/lsp` y se llama a `safe_require('plugins.lsp.diagnostics')` para apuntar al módulo real existente.
- Estos cambios solo corrigen rutas internas y no alteran la lógica funcional del resto de la configuración.

### Testing
- Se ejecutó un script estático con `python3` que analiza todos los `require(...)` en `config/nvim/lua` y confirmó que no quedan rutas internas faltantes tras los cambios (éxito).
- Se intentó validar en tiempo de ejecución con `XDG_CONFIG_HOME=/workspace/dotfiles/config nvim --headless '+qa'` pero falló porque `nvim` no está instalado en el entorno (no se pudo ejecutar la validación runtime).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0278f1e7c832aaeba5791b73ed49d)