### PR TITLE
Make GNU Stow the default deploy method; add Alacritty and WezTerm installers; update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,36 @@ chmod +x install.sh
 El script permite:
 
 - Instalar dependencias APT comunes de desarrollo.
-- Enlazar (default y recomendado) o copiar dotfiles al `$HOME`.
-- Instalar herramientas opcionales (Bun, Node.js con FNM, Yarn, lazygit).
+- Aplicar dotfiles con **GNU Stow** (default y recomendado) o copiarlos al `$HOME`.
+- Instalar herramientas opcionales (Bun, Node.js con FNM, Yarn, lazygit, Alacritty y WezTerm).
 - Instalar aplicaciones por `snap` (VS Code, Spotify, Android Studio, Neovim).
+
+> Para WezTerm, el instalador configura el repositorio oficial APT de WezTerm (`apt.fury.io/wez`) e instala el paquete `wezterm`.
 
 También podés usar modo rápido sin menú:
 
 ```bash
-# Instala todo usando enlaces simbólicos (default)
+# Instala todo usando GNU Stow (default)
 ./install.sh --all
 
 # Instala todo copiando archivos (opcional)
 ./install.sh --all --copy
 ```
 
-## Enlace simbólico vs copia
+## GNU Stow vs copia
 
-- **Enlazar (default)**: cualquier cambio en este repo se refleja inmediatamente en tu entorno.
+- **GNU Stow (default)**: cualquier cambio en este repo se refleja inmediatamente en tu entorno mediante symlinks ordenados por paquete.
 - **Copiar**: deja una copia estática de la configuración en tu `$HOME`.
+
+### Paquetes Stow
+
+> Nota: no se guarda una carpeta `stow/` en el repo. El instalador genera una estructura temporal de paquetes desde `config/` para evitar duplicación.
+
+- `shell` → `~/.zshrc`, `~/.zsh_aliases`, `~/.bashrc`
+- `nvim` → `~/.config/nvim`
+- `kitty` → `~/.config/kitty/kitty.conf`
+- `alacritty` → `~/.config/alacritty/alacritty.toml`
+- `wezterm` → `~/.config/wezterm/wezterm.lua`
 
 ## Ruta de configs destino
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ El script permite:
 - Instalar aplicaciones por `snap` (VS Code, Spotify, Android Studio, Neovim).
 
 > Para WezTerm, el instalador configura el repositorio oficial APT de WezTerm (`apt.fury.io/wez`) e instala el paquete `wezterm`.
+> Si venías del modo de enlaces antiguo, el instalador limpia symlinks heredados en rutas administradas antes de aplicar Stow para evitar conflictos.
 
 También podés usar modo rápido sin menú:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ El script permite:
 - Aplicar dotfiles con **GNU Stow** (default y recomendado) o copiarlos al `$HOME`.
 - Instalar herramientas opcionales (Bun, Node.js con FNM, Yarn, lazygit, Alacritty y WezTerm).
 - Instalar aplicaciones por `snap` (VS Code, Spotify, Android Studio, Neovim).
+- Instalar en lote los terminales (`Alacritty + WezTerm`) desde el menú.
 
 > Para WezTerm, el instalador configura el repositorio oficial APT de WezTerm (`apt.fury.io/wez`) e instala el paquete `wezterm`.
 > Si venías del modo de enlaces antiguo, el instalador limpia symlinks heredados en rutas administradas antes de aplicar Stow para evitar conflictos.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ El script permite:
 - Instalar herramientas opcionales (Bun, Node.js con FNM, Yarn, lazygit, Alacritty y WezTerm).
 - Instalar aplicaciones por `snap` (VS Code, Spotify, Android Studio, Neovim).
 - Instalar en lote los terminales (`Alacritty + WezTerm`) desde el menú.
+- Atajo en menú: `5) Alacritty + WezTerm`, `6) Alacritty`, `7) WezTerm`.
 
 > Para WezTerm, el instalador configura el repositorio oficial APT de WezTerm (`apt.fury.io/wez`) e instala el paquete `wezterm`.
 > Si venías del modo de enlaces antiguo, el instalador limpia symlinks heredados en rutas administradas antes de aplicar Stow para evitar conflictos.

--- a/install.sh
+++ b/install.sh
@@ -436,12 +436,16 @@ if [[ "${1:-}" == "--all" ]]; then
 fi
 
 # ---- Menú (coincide por número con $REPLY) ----
+echo "Atajos terminales: 5) Alacritty + WezTerm | 6) Alacritty | 7) WezTerm"
 PS3="Elegí una opción: "
 select opcion in \
   "Instalar todo" \
   "Instalar paquetes" \
   "Aplicar dotfiles con GNU Stow" \
   "Copiar archivos de configuración" \
+  "Instalar terminales (Alacritty + WezTerm)" \
+  "Instalar Alacritty" \
+  "Instalar WezTerm (repo oficial APT)" \
   "Instalar Bun" \
   "Instalar Oh My Zsh" \
   "Instalar kitty-themes" \
@@ -449,9 +453,6 @@ select opcion in \
   "Instalar Spotify" \
   "Instalar Visual Studio Code" \
   "Instalar nvim" \
-  "Instalar terminales (Alacritty + WezTerm)" \
-  "Instalar Alacritty" \
-  "Instalar WezTerm" \
   "Instalar Node.js" \
   "Instalar Yarn" \
   "Instalar lazygit" \
@@ -462,16 +463,16 @@ select opcion in \
     2) install_packages ;;
     3) stow_config_files ;;
     4) copy_config_files ;;
-    5) install_bun ;;
-    6) install_oh_my_zsh ;;
-    7) install_kitty_themes ;;
-    8) install_android_studio ;;
-    9) install_spotify ;;
-    10) install_vscode ;;
-    11) install_nvim ;;
-    12) install_terminal_emulators ;;
-    13) install_alacritty ;;
-    14) install_wezterm ;;
+    5) install_terminal_emulators ;;
+    6) install_alacritty ;;
+    7) install_wezterm ;;
+    8) install_bun ;;
+    9) install_oh_my_zsh ;;
+    10) install_kitty_themes ;;
+    11) install_android_studio ;;
+    12) install_spotify ;;
+    13) install_vscode ;;
+    14) install_nvim ;;
     15) install_nodejs ;;
     16) install_yarn ;;
     17) install_lazygit ;;

--- a/install.sh
+++ b/install.sh
@@ -312,6 +312,12 @@ install_wezterm() {
   ok "WezTerm instalado desde repositorio oficial."
 }
 
+install_terminal_emulators() {
+  log "Instalando emuladores de terminal (Alacritty + WezTerm)..."
+  install_alacritty
+  install_wezterm
+}
+
 # ---- Yarn (keyring) ----
 install_yarn() {
   if command -v yarn >/dev/null 2>&1; then
@@ -408,8 +414,7 @@ install_all() {
   install_spotify
   install_vscode
   install_nvim
-  install_alacritty
-  install_wezterm
+  install_terminal_emulators
   install_nerd_fonts
   install_yarn
   install_kitty_themes
@@ -444,6 +449,7 @@ select opcion in \
   "Instalar Spotify" \
   "Instalar Visual Studio Code" \
   "Instalar nvim" \
+  "Instalar terminales (Alacritty + WezTerm)" \
   "Instalar Alacritty" \
   "Instalar WezTerm" \
   "Instalar Node.js" \
@@ -463,13 +469,14 @@ select opcion in \
     9) install_spotify ;;
     10) install_vscode ;;
     11) install_nvim ;;
-    12) install_alacritty ;;
-    13) install_wezterm ;;
-    14) install_nodejs ;;
-    15) install_yarn ;;
-    16) install_lazygit ;;
-    17) clean ;;
-    18) exit 0 ;;
+    12) install_terminal_emulators ;;
+    13) install_alacritty ;;
+    14) install_wezterm ;;
+    15) install_nodejs ;;
+    16) install_yarn ;;
+    17) install_lazygit ;;
+    18) clean ;;
+    19) exit 0 ;;
     *) echo "Opción inválida." ;;
   esac
 done

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ trap 'echo -e "\n'"$ERR"' Ocurrió un error. Revisá el mensaje anterior."' ERR
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR"
-CONFIG_MODE="${DOTFILES_CONFIG_MODE:-link}" # link (default) | copy
+CONFIG_MODE="${DOTFILES_CONFIG_MODE:-stow}" # stow (default) | copy
 
 command -v sudo >/dev/null 2>&1 || die "Necesitás sudo instalado."
 command -v curl >/dev/null 2>&1 || die "Necesitás curl (sudo apt install curl)."
@@ -93,45 +93,53 @@ check_directory_exists() {
   }
 }
 
-# ---- Enlace/Copia de config ----
-link_config_files() {
-  log "Creando enlaces simbólicos desde 'config'..."
+# ---- Stow/Copia de config ----
+stow_config_files() {
+  log "Aplicando dotfiles con GNU Stow..."
+  install_package_if_not_installed stow
   local success="true"
+  local stow_dir
+  local -a stow_packages=(shell nvim kitty alacritty wezterm)
+  local pkg
+  stow_dir="$(mktemp -d)"
 
-  if check_file_exists "config/.zshrc"; then ln -snf "$REPO_ROOT/config/.zshrc" "$HOME/.zshrc" && ok ".zshrc enlazado" || success="false"; fi
-  if check_file_exists "config/.zsh_aliases"; then ln -snf "$REPO_ROOT/config/.zsh_aliases" "$HOME/.zsh_aliases" && ok ".zsh_aliases enlazado" || success="false"; fi
-  if check_file_exists "config/.bashrc"; then ln -snf "$REPO_ROOT/config/.bashrc" "$HOME/.bashrc" && ok ".bashrc enlazado" || success="false"; fi
+  mkdir -p \
+    "$stow_dir/shell" \
+    "$stow_dir/nvim/.config" \
+    "$stow_dir/kitty/.config/kitty" \
+    "$stow_dir/alacritty/.config/alacritty" \
+    "$stow_dir/wezterm/.config/wezterm"
 
-  if check_directory_exists "config/nvim"; then
-    mkdir -p "$HOME/.config"
-    ln -snf "$REPO_ROOT/config/nvim" "$HOME/.config/nvim" && ok "nvim enlazado" || success="false"
-  fi
+  ln -snf "$REPO_ROOT/config/.zshrc" "$stow_dir/shell/.zshrc"
+  ln -snf "$REPO_ROOT/config/.bashrc" "$stow_dir/shell/.bashrc"
+  [[ -f "$REPO_ROOT/config/.zsh_aliases" ]] && ln -snf "$REPO_ROOT/config/.zsh_aliases" "$stow_dir/shell/.zsh_aliases"
 
-  if check_file_exists "config/kitty.conf"; then
-    mkdir -p "$HOME/.config/kitty"
-    ln -snf "$REPO_ROOT/config/kitty.conf" "$HOME/.config/kitty/kitty.conf" && ok "kitty.conf enlazado" || success="false"
-  fi
+  ln -snf "$REPO_ROOT/config/nvim" "$stow_dir/nvim/.config/nvim"
+  ln -snf "$REPO_ROOT/config/kitty.conf" "$stow_dir/kitty/.config/kitty/kitty.conf"
+  ln -snf "$REPO_ROOT/config/alacritty/alacritty.toml" "$stow_dir/alacritty/.config/alacritty/alacritty.toml"
+  ln -snf "$REPO_ROOT/config/wezterm.lua" "$stow_dir/wezterm/.config/wezterm/wezterm.lua"
 
-  if check_file_exists "config/alacritty/alacritty.toml"; then
-    mkdir -p "$HOME/.config/alacritty"
-    ln -snf "$REPO_ROOT/config/alacritty/alacritty.toml" "$HOME/.config/alacritty/alacritty.toml" && ok "alacritty.toml enlazado" || success="false"
-  fi
+  for pkg in "${stow_packages[@]}"; do
+    if [[ -d "$stow_dir/$pkg" ]]; then
+      stow --restow --dir "$stow_dir" --target "$HOME" "$pkg" \
+        && ok "Paquete Stow '$pkg' aplicado" \
+        || success="false"
+    else
+      warn "Paquete Stow '$pkg' no encontrado. Saltando..."
+    fi
+  done
 
-  if check_file_exists "config/wezterm.lua"; then
-    mkdir -p "$HOME/.config/wezterm"
-    ln -snf "$REPO_ROOT/config/wezterm.lua" "$HOME/.config/wezterm/wezterm.lua" && ok "wezterm.lua enlazado" || success="false"
-  fi
-
-  [[ "$success" = true ]] && ok "Enlaces simbólicos creados" || die "Error creando enlaces simbólicos."
+  rm -rf "$stow_dir"
+  [[ "$success" = true ]] && ok "Dotfiles aplicados con Stow" || die "Error aplicando dotfiles con Stow."
 }
 
 copy_config_files() {
   log "Copiando archivos de configuración desde 'config'..."
   local success="true"
 
-  if check_file_exists "config/.zshrc"; then cp -f "$REPO_ROOT/config/.zshrc" "$HOME/" && ok ".zshrc copiado" || success="false"; fi
-  if check_file_exists "config/.zsh_aliases"; then cp -f "$REPO_ROOT/config/.zsh_aliases" "$HOME/" && ok ".zsh_aliases copiado" || success="false"; fi
-  if check_file_exists "config/.bashrc"; then cp -f "$REPO_ROOT/config/.bashrc" "$HOME/" && ok ".bashrc copiado" || success="false"; fi
+  if check_file_exists "config/.zshrc"; then cp -f "$REPO_ROOT/config/.zshrc" "$HOME/.zshrc" && ok ".zshrc copiado" || success="false"; fi
+  if check_file_exists "config/.zsh_aliases"; then cp -f "$REPO_ROOT/config/.zsh_aliases" "$HOME/.zsh_aliases" && ok ".zsh_aliases copiado" || success="false"; fi
+  if check_file_exists "config/.bashrc"; then cp -f "$REPO_ROOT/config/.bashrc" "$HOME/.bashrc" && ok ".bashrc copiado" || success="false"; fi
 
   if check_directory_exists "config/nvim"; then
     mkdir -p "$HOME/.config"
@@ -140,7 +148,7 @@ copy_config_files() {
 
   if check_file_exists "config/kitty.conf"; then
     mkdir -p "$HOME/.config/kitty"
-    cp -f "$REPO_ROOT/config/kitty.conf" "$HOME/.config/kitty/" && ok "kitty.conf copiado" || success="false"
+    cp -f "$REPO_ROOT/config/kitty.conf" "$HOME/.config/kitty/kitty.conf" && ok "kitty.conf copiado" || success="false"
   fi
 
   if check_file_exists "config/alacritty/alacritty.toml"; then
@@ -158,15 +166,15 @@ copy_config_files() {
 
 apply_config_files() {
   case "$CONFIG_MODE" in
-    link)
-      log "Modo configuración: enlaces simbólicos (default)."
-      link_config_files
+    stow)
+      log "Modo configuración: GNU Stow (default)."
+      stow_config_files
       ;;
     copy)
       log "Modo configuración: copia de archivos."
       copy_config_files
       ;;
-    *) die "DOTFILES_CONFIG_MODE inválido: '$CONFIG_MODE'. Usá 'link' o 'copy'." ;;
+    *) die "DOTFILES_CONFIG_MODE inválido: '$CONFIG_MODE'. Usá 'stow' o 'copy'." ;;
   esac
 }
 # ---- Oh My Zsh ----
@@ -255,6 +263,38 @@ install_nvim() {
   log "Instalando Neovim (snap beta)..."
   sudo snap install nvim --beta --classic || die "Fallo instalando Neovim."
   ok "Neovim instalado."
+}
+
+# ---- Terminal emulators ----
+install_alacritty() {
+  if command -v alacritty >/dev/null 2>&1; then
+    ok "Alacritty ya está instalado. Saltando..."
+    return
+  fi
+  log "Instalando Alacritty..."
+  install_package_if_not_installed alacritty
+  ok "Alacritty instalado."
+}
+
+install_wezterm() {
+  if command -v wezterm >/dev/null 2>&1; then
+    ok "WezTerm ya está instalado. Saltando..."
+    return
+  fi
+
+  log "Configurando repositorio oficial APT de WezTerm..."
+  sudo mkdir -p /usr/share/keyrings
+  curl -fsSL https://apt.fury.io/wez/gpg.key | sudo gpg --yes --dearmor -o /usr/share/keyrings/wezterm-fury.gpg \
+    || die "No se pudo importar la key GPG de WezTerm."
+  echo 'deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' \
+    | sudo tee /etc/apt/sources.list.d/wezterm.list >/dev/null \
+    || die "No se pudo configurar el repo APT de WezTerm."
+  sudo chmod 644 /usr/share/keyrings/wezterm-fury.gpg || die "No se pudieron ajustar permisos de la key de WezTerm."
+
+  log "Actualizando índices de APT e instalando WezTerm..."
+  sudo apt update
+  sudo apt install -y wezterm || die "Fallo instalando WezTerm desde el repo oficial."
+  ok "WezTerm instalado desde repositorio oficial."
 }
 
 # ---- Yarn (keyring) ----
@@ -353,6 +393,8 @@ install_all() {
   install_spotify
   install_vscode
   install_nvim
+  install_alacritty
+  install_wezterm
   install_nerd_fonts
   install_yarn
   install_kitty_themes
@@ -367,7 +409,7 @@ if [[ "${1:-}" == "--all" ]]; then
   if [[ "${2:-}" == "--copy" ]]; then
     CONFIG_MODE="copy"
   else
-    CONFIG_MODE="link"
+    CONFIG_MODE="stow"
   fi
   install_all
   exit 0
@@ -378,7 +420,7 @@ PS3="Elegí una opción: "
 select opcion in \
   "Instalar todo" \
   "Instalar paquetes" \
-  "Enlazar archivos de configuración" \
+  "Aplicar dotfiles con GNU Stow" \
   "Copiar archivos de configuración" \
   "Instalar Bun" \
   "Instalar Oh My Zsh" \
@@ -387,6 +429,8 @@ select opcion in \
   "Instalar Spotify" \
   "Instalar Visual Studio Code" \
   "Instalar nvim" \
+  "Instalar Alacritty" \
+  "Instalar WezTerm" \
   "Instalar Node.js" \
   "Instalar Yarn" \
   "Instalar lazygit" \
@@ -395,7 +439,7 @@ select opcion in \
   case "$REPLY" in
     1) install_all ;;
     2) install_packages ;;
-    3) link_config_files ;;
+    3) stow_config_files ;;
     4) copy_config_files ;;
     5) install_bun ;;
     6) install_oh_my_zsh ;;
@@ -404,11 +448,13 @@ select opcion in \
     9) install_spotify ;;
     10) install_vscode ;;
     11) install_nvim ;;
-    12) install_nodejs ;;
-    13) install_yarn ;;
-    14) install_lazygit ;;
-    15) clean ;;
-    16) exit 0 ;;
+    12) install_alacritty ;;
+    13) install_wezterm ;;
+    14) install_nodejs ;;
+    15) install_yarn ;;
+    16) install_lazygit ;;
+    17) clean ;;
+    18) exit 0 ;;
     *) echo "Opción inválida." ;;
   esac
 done

--- a/install.sh
+++ b/install.sh
@@ -110,14 +110,29 @@ stow_config_files() {
     "$stow_dir/alacritty/.config/alacritty" \
     "$stow_dir/wezterm/.config/wezterm"
 
-  ln -snf "$REPO_ROOT/config/.zshrc" "$stow_dir/shell/.zshrc"
-  ln -snf "$REPO_ROOT/config/.bashrc" "$stow_dir/shell/.bashrc"
-  [[ -f "$REPO_ROOT/config/.zsh_aliases" ]] && ln -snf "$REPO_ROOT/config/.zsh_aliases" "$stow_dir/shell/.zsh_aliases"
+  # Limpia enlaces simbólicos heredados (modo link antiguo) para evitar conflictos con Stow.
+  local -a legacy_targets=(
+    "$HOME/.zshrc"
+    "$HOME/.zsh_aliases"
+    "$HOME/.bashrc"
+    "$HOME/.config/nvim"
+    "$HOME/.config/kitty/kitty.conf"
+    "$HOME/.config/alacritty/alacritty.toml"
+    "$HOME/.config/wezterm/wezterm.lua"
+  )
+  local target
+  for target in "${legacy_targets[@]}"; do
+    [[ -L "$target" ]] && rm -f "$target"
+  done
 
-  ln -snf "$REPO_ROOT/config/nvim" "$stow_dir/nvim/.config/nvim"
-  ln -snf "$REPO_ROOT/config/kitty.conf" "$stow_dir/kitty/.config/kitty/kitty.conf"
-  ln -snf "$REPO_ROOT/config/alacritty/alacritty.toml" "$stow_dir/alacritty/.config/alacritty/alacritty.toml"
-  ln -snf "$REPO_ROOT/config/wezterm.lua" "$stow_dir/wezterm/.config/wezterm/wezterm.lua"
+  cp -f "$REPO_ROOT/config/.zshrc" "$stow_dir/shell/.zshrc"
+  cp -f "$REPO_ROOT/config/.bashrc" "$stow_dir/shell/.bashrc"
+  [[ -f "$REPO_ROOT/config/.zsh_aliases" ]] && cp -f "$REPO_ROOT/config/.zsh_aliases" "$stow_dir/shell/.zsh_aliases"
+
+  cp -a "$REPO_ROOT/config/nvim" "$stow_dir/nvim/.config/nvim"
+  cp -f "$REPO_ROOT/config/kitty.conf" "$stow_dir/kitty/.config/kitty/kitty.conf"
+  cp -f "$REPO_ROOT/config/alacritty/alacritty.toml" "$stow_dir/alacritty/.config/alacritty/alacritty.toml"
+  cp -f "$REPO_ROOT/config/wezterm.lua" "$stow_dir/wezterm/.config/wezterm/wezterm.lua"
 
   for pkg in "${stow_packages[@]}"; do
     if [[ -d "$stow_dir/$pkg" ]]; then


### PR DESCRIPTION
### Motivation

- Replace ad-hoc symlink deployment with GNU Stow to manage dotfiles as packages and avoid duplicated paths.
- Provide first-class installers for Alacritty and WezTerm and automate repo/key setup for WezTerm.
- Update documentation to reflect the new Stow-based workflow and list Stow package mappings.

### Description

- Change default configuration mode from `link` to `stow` and update CLI/menu defaults to use `stow` or `copy`.
- Add `stow_config_files()` which generates a temporary stow package tree from `config/`, ensures `stow` is installed, and applies packages (`shell`, `nvim`, `kitty`, `alacritty`, `wezterm`) with `stow --restow`.
- Adjust copy behaviour to write files into explicit target paths (e.g. copy to `~/.config/kitty/kitty.conf`) and remove the old symlink function.
- Add `install_alacritty()` and `install_wezterm()` functions; `install_wezterm()` configures the official WezTerm APT repo and GPG key, updates APT and installs `wezterm`.
- Update `install_all()` to include Alacritty and WezTerm installation and extend the interactive menu with new entries.
- Update `README.md` to document GNU Stow usage, Stow package mapping, and the WezTerm APT install behavior.

### Testing

- Performed a shell syntax check with `bash -n install.sh`, which completed without syntax errors.
- No automated unit tests are present for this repository and no other automated test suite was run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db956ce560832aa6f108dc4f86f7de)